### PR TITLE
Add makefile

### DIFF
--- a/demo_makefile/.gitignore
+++ b/demo_makefile/.gitignore
@@ -1,0 +1,9 @@
+# Ignore binaries from examples
+*.o
+*.d
+*.map
+*.lss
+*.elf
+*.bin
+*.sym
+*.hex

--- a/demo_makefile/main.c
+++ b/demo_makefile/main.c
@@ -1,0 +1,57 @@
+/**
+ * @file main.c
+ * 
+ * @author Tiago Lobao
+ * 
+ * @brief Blink example based on the example for atmega328p
+ * https://github.com/feilipu/avrfreertos/blob/master/UnoBlink/main.c
+ * 
+ */
+
+/* Scheduler include files. */
+#include "FreeRTOS.h"
+#include "task.h"
+
+/*-----------------------------------------------------------*/
+static void TaskBlinkLED(void *pvParameters);
+/*-----------------------------------------------------------*/
+
+/* Main program loop */
+
+int main(void)
+{
+    xTaskCreate(
+		TaskBlinkLED
+		,  (const char *)"GreenLED"
+		,  256
+		,  NULL
+		,  3
+		,  NULL );
+
+
+	vTaskStartScheduler();
+    
+}
+
+/*-----------------------------------------------------------*/
+static void TaskBlinkLED(void *pvParameters) // Main Green LED Flash
+{
+    (void) pvParameters;
+    TickType_t xLastWakeTime;
+
+	xLastWakeTime = xTaskGetTickCount();
+
+	DDRB |= _BV(DDB5);
+
+    for(;;)
+    {
+    	PORTB |=  _BV(PORTB5);       // main (red PB5) LED on. Arduino LED on
+		vTaskDelayUntil( &xLastWakeTime, ( 500 / portTICK_PERIOD_MS ) );
+
+		PORTB &= ~_BV(PORTB5);       // main (red PB5) LED off. Arduino LED off
+		vTaskDelayUntil( &xLastWakeTime, ( 500 / portTICK_PERIOD_MS )  );
+
+    }
+}
+
+/*---------------------------------------------------------------------------*/

--- a/demo_makefile/main.c
+++ b/demo_makefile/main.c
@@ -16,8 +16,6 @@
 static void TaskBlinkLED(void *pvParameters);
 /*-----------------------------------------------------------*/
 
-/* Main program loop */
-
 int main(void)
 {
     xTaskCreate(
@@ -29,8 +27,7 @@ int main(void)
 		,  NULL );
 
 
-	vTaskStartScheduler();
-    
+	vTaskStartScheduler();    
 }
 
 /*-----------------------------------------------------------*/

--- a/demo_makefile/makefile
+++ b/demo_makefile/makefile
@@ -1,0 +1,125 @@
+# Make file based on 
+# https://github.com/peakhunt/freertos_atmega328p/blob/master/Makefile
+# and modified by Tiago Lobao
+#
+# 
+# make (default) = compile project
+#
+# make clean = delete all binaries
+#
+# make program = flash through AVRDUDE
+#
+
+# ---------------------------------------
+# -------- MAKEFILE USER DEFINES --------
+# ---------------------------------------
+
+# ---------------------------------------
+# Microcontroller specific
+MCU=atmega328p
+F_CPU=16000000UL
+
+# ---------------------------------------
+# Directiory for the freeRTOS
+FREERTOS_DIR=..
+
+# ---------------------------------------
+# Flashing options
+# using standard arduino bootloader
+AVRDUDE_PROGRAMMER = arduino
+AVRDUDE_PORT = COM3
+AVRDUDE_BAUDRATE = 115200
+
+# ---------------------------------------
+# Target options
+TARGET=main.hex
+
+# ---------------------------------------
+# compiler / programmer options
+CC=avr-gcc
+AVRDUDE = avrdude
+
+# ---------------------------------------
+# Sources/includes to be used
+FREERTOS_SRC  :=  \
+	$(FREERTOS_DIR)/list.c \
+	$(FREERTOS_DIR)/timers.c \
+	$(FREERTOS_DIR)/stream_buffer.c \
+	$(FREERTOS_DIR)/heap_3.c \
+	$(FREERTOS_DIR)/event_groups.c \
+	$(FREERTOS_DIR)/hooks.c \
+	$(FREERTOS_DIR)/port.c \
+	$(FREERTOS_DIR)/queue.c \
+	$(FREERTOS_DIR)/tasks.c
+
+
+SOURCES :=	$(FREERTOS_SRC) \
+	main.c
+
+INC_PATH=-I$(FREERTOS_DIR) -I./
+
+
+# ---------------------------------------
+# ---------- MAKEFILE CODE --------------
+# ---------------------------------------
+
+AVRDUDE_WRITE_FLASH = -U flash:w:$(TARGET)
+AVRDUDE_FLAGS = -p $(MCU) -b $(AVRDUDE_BAUDRATE)
+AVRDUDE_FLAGS += -P $(AVRDUDE_PORT)
+AVRDUDE_FLAGS += -c $(AVRDUDE_PROGRAMMER)
+AVRDUDE_VERBOSE = -v -v
+
+CFLAGS = -mmcu=$(MCU)
+CFLAGS += -funsigned-char -funsigned-bitfields -DDEBUG
+CFLAGS += -DF_CPU=$(F_CPU) 
+CFLAGS += $(INC_PATH)
+CFLAGS += -O2 -ffunction-sections -fdata-sections -fpack-struct -fshort-enums
+CFLAGS += -mrelax -Wall -Wstrict-prototypes
+CFLAGS += -std=gnu11 -Wundef
+CFLAGS += -MMD -MP -MF .dep/$(@F).d
+CFLAGS += -DBMP180_API
+
+LFLAGS = -mmcu=$(MCU)
+LFLAGS += -Wl,-Map=$(MAPFILE),--cref,--gc-sections
+LFLAGS += -lm
+
+OBJECTS := $(addprefix  obj/,$(SOURCES:.c=.o))
+LINKED := $(addprefix obj/, $(TARGET:.hex=.elf))
+BINARY := $(addprefix obj/, $(TARGET:.hex=.bin))
+MAPFILE := $(addprefix obj/, $(TARGET:.hex=.map))
+SYMFILE := $(addprefix obj/, $(TARGET:.hex=.sym))
+LSSFILE := $(addprefix obj/, $(TARGET:.hex=.lss))
+
+all: $(TARGET)
+
+$(TARGET): $(OBJECTS)
+	@echo "[LD]		$(TARGET)"
+	$Qavr-gcc $(LFLAGS) -o $(LINKED) $^
+	$Qavr-objcopy -O ihex -R .eeprom $(LINKED) $@
+	$Qavr-objcopy -I ihex $(TARGET) -O binary $(BINARY)
+	$Qavr-size --format=berkeley $(LINKED)
+	$Qavr-nm -n $(LINKED) > $(SYMFILE)
+	$Qavr-objdump -h -S $(LINKED) > $(LSSFILE)
+
+obj/%.o: %.c
+	@echo "[CC]		$(notdir $<)"
+	$Qmkdir -p $(dir $@)
+	$Q$(CC) $(CFLAGS) -c -o $@ $<
+
+program: $(TARGET)
+	$(AVRDUDE) $(AVRDUDE_FLAGS) $(AVRDUDE_WRITE_FLASH) $(AVRDUDE_WRITE_EEPROM)
+
+clean:
+	@echo "Cleaning $(TARGET)"
+	$Qrm -f $(TARGET)
+	$Qrm -f $(BINARY)
+	$Qrm -f $(MAPFILE)
+	$Qrm -f $(SYMFILE)
+	$Qrm -f $(LSSFILE)
+	@echo "Cleaning Objects"
+	$Qrm -f *.o
+	$Qrm -f $(TARGET)*.hex
+	$Qrm -rf obj
+	$Qrm -rf .dep
+
+-include $(shell mkdir .dep 2>/dev/null) $(wildcard .dep/*)

--- a/demo_makefile/makefile
+++ b/demo_makefile/makefile
@@ -31,8 +31,8 @@ AVRDUDE_PORT = COM3
 AVRDUDE_BAUDRATE = 115200
 
 # ---------------------------------------
-# Target options
-TARGET=main.hex
+# Target file name options
+TARGET=main
 
 # ---------------------------------------
 # compiler / programmer options
@@ -63,63 +63,41 @@ INC_PATH=-I$(FREERTOS_DIR) -I./
 # ---------- MAKEFILE CODE --------------
 # ---------------------------------------
 
-AVRDUDE_WRITE_FLASH = -U flash:w:$(TARGET)
+AVRDUDE_WRITE_FLASH = -U flash:w:$(TARGET).hex
 AVRDUDE_FLAGS = -p $(MCU) -b $(AVRDUDE_BAUDRATE)
 AVRDUDE_FLAGS += -P $(AVRDUDE_PORT)
 AVRDUDE_FLAGS += -c $(AVRDUDE_PROGRAMMER)
-AVRDUDE_VERBOSE = -v -v
 
-CFLAGS = -mmcu=$(MCU)
-CFLAGS += -funsigned-char -funsigned-bitfields -DDEBUG
-CFLAGS += -DF_CPU=$(F_CPU) 
-CFLAGS += $(INC_PATH)
-CFLAGS += -O2 -ffunction-sections -fdata-sections -fpack-struct -fshort-enums
-CFLAGS += -mrelax -Wall -Wstrict-prototypes
-CFLAGS += -std=gnu11 -Wundef
-CFLAGS += -MMD -MP -MF .dep/$(@F).d
-CFLAGS += -DBMP180_API
+MCUFLAGS = -mmcu=$(MCU) -DF_CPU=$(F_CPU)
 
-LFLAGS = -mmcu=$(MCU)
-LFLAGS += -Wl,-Map=$(MAPFILE),--cref,--gc-sections
-LFLAGS += -lm
+CFLAGS = $(MCUFLAGS)  $(INC_PATH) -c $(SOURCES)
+LFLAGS = $(MCUFLAGS) -o $(TARGET).elf *.o
 
-OBJECTS := $(addprefix  obj/,$(SOURCES:.c=.o))
-LINKED := $(addprefix obj/, $(TARGET:.hex=.elf))
-BINARY := $(addprefix obj/, $(TARGET:.hex=.bin))
-MAPFILE := $(addprefix obj/, $(TARGET:.hex=.map))
-SYMFILE := $(addprefix obj/, $(TARGET:.hex=.sym))
-LSSFILE := $(addprefix obj/, $(TARGET:.hex=.lss))
+# ---------------------------------------
+# Optimization choice
+# This will avoid not used code and guarantee proper delays
+CFLAGS += -ffunction-sections -O2
+LFLAGS += -Wl,--gc-sections
 
 all: $(TARGET)
 
-$(TARGET): $(OBJECTS)
-	@echo "[LD]		$(TARGET)"
-	$Qavr-gcc $(LFLAGS) -o $(LINKED) $^
-	$Qavr-objcopy -O ihex -R .eeprom $(LINKED) $@
-	$Qavr-objcopy -I ihex $(TARGET) -O binary $(BINARY)
-	$Qavr-size --format=berkeley $(LINKED)
-	$Qavr-nm -n $(LINKED) > $(SYMFILE)
-	$Qavr-objdump -h -S $(LINKED) > $(LSSFILE)
+$(TARGET):
+	$(CC) $(CFLAGS)
+	$(CC) $(LFLAGS)
+	avr-objcopy -O ihex $(TARGET).elf $(TARGET).hex
 
-obj/%.o: %.c
-	@echo "[CC]		$(notdir $<)"
-	$Qmkdir -p $(dir $@)
-	$Q$(CC) $(CFLAGS) -c -o $@ $<
-
-program: $(TARGET)
+program:
 	$(AVRDUDE) $(AVRDUDE_FLAGS) $(AVRDUDE_WRITE_FLASH) $(AVRDUDE_WRITE_EEPROM)
 
 clean:
 	@echo "Cleaning $(TARGET)"
-	$Qrm -f $(TARGET)
-	$Qrm -f $(BINARY)
-	$Qrm -f $(MAPFILE)
-	$Qrm -f $(SYMFILE)
-	$Qrm -f $(LSSFILE)
+	rm -f $(BINARY)
+	rm -f $(MAPFILE)
+	rm -f $(SYMFILE)
+	rm -f $(LSSFILE)
 	@echo "Cleaning Objects"
-	$Qrm -f *.o
-	$Qrm -f $(TARGET)*.hex
-	$Qrm -rf obj
-	$Qrm -rf .dep
-
--include $(shell mkdir .dep 2>/dev/null) $(wildcard .dep/*)
+	rm -f *.o
+	rm -f $(TARGET)*.hex
+	rm -f $(TARGET)*.elf
+	rm -rf obj
+	rm -rf .dep


### PR DESCRIPTION
Based on the Issue #2 I'd like to help adding an example of a makefile, compiling a blink project for atmega328p
For now it is limited to one MCU. Arduino UNO / Atmega328p

I have some remarks here described below, but the pull request has working code

1) strcpy
One thing that I've noticed by compiling it was those warnings here by compiling hooks.c:
```
../hooks.c: In function ‘vApplicationStackOverflowHook’:
../hooks.c:274:5: warning: implicit declaration of function ‘strcat’ [-Wimplicit-function-declaration]
strcat( (char*) pC, (char*) pcTaskName );
^
../hooks.c:274:5: warning: incompatible implicit declaration of built-in function ‘strcat’
../hooks.c:274:5: note: include ‘<string.h>’ or provide a declaration of ‘strcat’ 

```
should it be changed strcat to strcat_P ? they are the same right?

2) compilation errors
When I remove the compiler optimization to avoid non used code, it complains to the non resolved extern variable LineBuffer
```
avr-gcc -mmcu=atmega328p -DF_CPU=16000000UL -o main.elf *.o
hooks.o: In function `vApplicationStackOverflowHook':
hooks.c:(.text+0xa6): undefined reference to `LineBuffer'
hooks.c:(.text+0xaa): undefined reference to `LineBuffer'
hooks.c:(.text+0xdc): undefined reference to `LineBuffer'
hooks.c:(.text+0xe0): undefined reference to `LineBuffer'
collect2: error: ld returned 1 exit status       
```
Is it intentionally not resolved to be used defined?


