### PR TITLE
Add config option for ISR_NOBLOCK

### DIFF
--- a/FreeRTOSConfig.h
+++ b/FreeRTOSConfig.h
@@ -45,6 +45,7 @@
 
 /* And on to the things the same no matter the AVR type... */
 #define configUSE_PREEMPTION                1
+#define configUSE_PREEMPTION_NOBLOCK        0
 
 #define configCPU_CLOCK_HZ                  ( ( uint32_t ) F_CPU )          // This F_CPU variable set by the environment
 #define configMAX_PRIORITIES                4

--- a/port.c
+++ b/port.c
@@ -703,9 +703,12 @@ extern void prvSetupTimerInterrupt( void );
      * use ISR_NOBLOCK where there is an important timer running, that should preempt the scheduler.
      *
      */
-    ISR(portSCHEDULER_ISR, ISR_NAKED) __attribute__ ((hot, flatten));
-/*  ISR(portSCHEDULER_ISR, ISR_NAKED ISR_NOBLOCK) __attribute__ ((hot, flatten));
- */
+    # if configUSE_PREEMPTION_NOBLOCK == 1
+        ISR(portSCHEDULER_ISR, ISR_NAKED ISR_NOBLOCK) __attribute__ ((hot, flatten));
+    # else
+        ISR(portSCHEDULER_ISR, ISR_NAKED) __attribute__ ((hot, flatten));
+    #endif
+
     ISR(portSCHEDULER_ISR)
     {
         vPortYieldFromTick();


### PR DESCRIPTION
This introduces a non-breaking change to enable `ISR_NOBLOCK` via config option. If the option is missing, then it falls back to not enabling `ISR_NOBLOCK`.

Mentioned in #9.